### PR TITLE
Improvement/dark mode and mobile updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maple-dailies",
-  "version": "0.0.0",
+  "version": "1.0.2",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/framework/form/checkbox/checkbox.component.html
+++ b/src/app/framework/form/checkbox/checkbox.component.html
@@ -1,7 +1,7 @@
 <label class="flex items-center space-x-3 ml-3">
   <input
     type="checkbox"
-    class="form-tick cursor-pointer appearance-none h-6 w-6 border border-gray-300 rounded-md bg-gray-50 dark:bg-white checked:bg-blue-600 checked:border-transparent focus:outline-none"
+    class="form-tick cursor-pointer appearance-none h-6 w-6 border border-gray-300 rounded-md bg-gray-50 dark:bg-white checked:bg-indigo-900 dark:checked:bg-indigo-900 checked:border-transparent focus:outline-none"
     [checked]="value"
   />
   <ng-content></ng-content>

--- a/src/app/layout/breadcrumb-nav/breadcrumb-nav.component.html
+++ b/src/app/layout/breadcrumb-nav/breadcrumb-nav.component.html
@@ -1,7 +1,7 @@
 <ul class="flex md:flex-row flex-col items-center lowercase space-x-3 mb-3">
   <li *ngFor="let navLink of navLinks; index as i" class="space-x-2 font-thin">
     <a
-      class="text-gray-500 dark:text-white hover:text-gray-700 dark:hover:text-gray-200"
+      class="text-gray-500 dark:text-white hover:text-gray-700 dark:hover:text-gray-200 dark:visited:text-white"
       [routerLink]="navLink.route"
       [routerLinkActiveOptions]="{ exact: true }"
       routerLinkActive="text-gray-900 dark:text-white font-normal"

--- a/src/app/layout/footer/footer.component.html
+++ b/src/app/layout/footer/footer.component.html
@@ -1,18 +1,23 @@
 <footer
   class="flex justify-center items-center h-16 p-2 bg-gray-50 border-t border-gray-200 text-gray-700 dark:text-gray-300 dark:border-gray-800 dark:bg-gray-900"
 >
-  <span class="cursor-pointer">
-    <a href="https://vizhnay.dev"></a>
-    <fa-icon [icon]="homepageIcon"></fa-icon>
+  <span class="cursor-pointer" title="Visit me!">
+    <a href="https://vizhnay.dev" target="_blank">
+      <fa-icon [icon]="homepageIcon"></fa-icon>
+    </a>
   </span>
   <span class="mx-2">/</span>
-  <span class="cursor-pointer">
+  <span class="cursor-pointer" title="Source code!">
     <a href="https://github.com/vzhny/maple-dailies" target="_blank">
       <fa-icon [icon]="githubIcon"></fa-icon>
     </a>
   </span>
   <span class="mx-2">/</span>
-  <span class="cursor-pointer" (click)="toggleDarkMode()">
+  <span
+    class="cursor-pointer"
+    (click)="toggleDarkMode()"
+    title="{{ darkModeEnabled ? 'Disable' : 'Enable' }} dark mode!"
+  >
     <fa-icon [icon]="darkModeEnabled ? darkModeIcon : lightModeIcon"></fa-icon>
   </span>
 </footer>

--- a/src/app/pages/guides/components/arcane-river-dailies-lists/arcane-river-dailies-lists.component.html
+++ b/src/app/pages/guides/components/arcane-river-dailies-lists/arcane-river-dailies-lists.component.html
@@ -22,7 +22,7 @@
       <ul>
         <li
           *ngFor="let daily of item.dailies"
-          class="font-normal ml-5"
+          class="font-normal md:ml-5"
           [ngClass]="{ 'font-medium text-red-500': daily.exchangeFlag }"
         >
           {{ daily.name }}

--- a/src/app/pages/guides/components/hard-muto-recipes/components/muto-recipe/muto-recipe.component.html
+++ b/src/app/pages/guides/components/hard-muto-recipes/components/muto-recipe/muto-recipe.component.html
@@ -1,11 +1,25 @@
 <div
   *ngIf="recipe !== null"
   class="h-full shadow border-b dark:border-black rounded-md bg-white dark:bg-gray-800"
+  [ngClass]="{
+    'bg-indigo-800 text-white dark:bg-indigo-800 dark:text-white':
+      recipe.canHaveHiddenIngredientsFlg
+  }"
 >
-  <div class="p-2 border-b dark:border-black">
+  <div
+    class="p-2 border-b dark:border-black"
+    [ngClass]="{
+      'bg-indigo-900 dark:bg-indigo-900': recipe.canHaveHiddenIngredientsFlg
+    }"
+  >
     {{ recipe.name }}
   </div>
-  <div class="flex justify-between items-center p-2">
+  <div
+    class="flex justify-between items-center p-2"
+    [ngClass]="{
+      'bg-indigo-800 dark:bg-indigo-800': recipe.canHaveHiddenIngredientsFlg
+    }"
+  >
     <app-muto-recipe-ingredient-info
       [ingredient]="recipe.ingredient1"
     ></app-muto-recipe-ingredient-info>
@@ -13,13 +27,28 @@
       [ingredient]="recipe.ingredient2"
     ></app-muto-recipe-ingredient-info>
   </div>
-  <div class="flex justify-between items-center p-2">
-    <div *ngIf="recipe.ingredient3">
+  <div
+    class="flex justify-between items-center p-2"
+    [ngClass]="{
+      'bg-indigo-800 dark:bg-indigo-800': recipe.canHaveHiddenIngredientsFlg
+    }"
+  >
+    <div
+      *ngIf="recipe.ingredient3"
+      [ngClass]="{
+        'bg-indigo-800 dark:bg-indigo-800': recipe.canHaveHiddenIngredientsFlg
+      }"
+    >
       <app-muto-recipe-ingredient-info
         [ingredient]="recipe.ingredient3"
       ></app-muto-recipe-ingredient-info>
     </div>
-    <div *ngIf="recipe.ingredient4">
+    <div
+      *ngIf="recipe.ingredient4"
+      [ngClass]="{
+        'bg-indigo-800 dark:bg-indigo-800': recipe.canHaveHiddenIngredientsFlg
+      }"
+    >
       <app-muto-recipe-ingredient-info
         [ingredient]="recipe.ingredient4"
       ></app-muto-recipe-ingredient-info>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,6 +10,9 @@ module.exports = {
   },
   darkMode: "class", // or 'media' or 'class'
   theme: {
+    container: {
+      padding: "1rem",
+    },
     extend: {
       colors: {
         transparent: "transparent",
@@ -32,6 +35,7 @@ module.exports = {
       backgroundColor: ["checked"],
       borderColor: ["checked", "last"],
       borderWidth: ["last"],
+      textColor: ["visited"],
     },
   },
   plugins: [],


### PR DESCRIPTION
This PR includes updates to the checkbox and muto recipe components, accentuating them in dark (and light) mode. It also fixes the homepage footer icon link, as well as adds hover titles to said icons.