### PR TITLE
Improvement/default to dashboard page on app load

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maple-dailies",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -20,7 +20,7 @@ export class AppComponent implements OnInit {
   ngOnInit(): void {
     this.setLocalStorageWatchers();
     this.handleSettingDarkMode();
-    this.appAccessService.processLatestAppAccess({ reroute: true, route: '/dailies' });
+    this.appAccessService.processLatestAppAccess({ reroute: true, route: '/dashboard' });
   }
 
   setLocalStorageWatchers() {

--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -54,7 +54,12 @@ export class DashboardComponent implements OnInit {
 
     this.bossService.watchBossesChecklists().subscribe((checklists) => {
       if (checklists !== null) {
-        this.bossesChecklists = checklists;
+        this.bossesChecklists = checklists.filter((checklist) => {
+          const hasSelectedDailyBosses = checklist.dailyBosses.filter((boss) => boss.selected).length > 0;
+          const hasSelectedWeeklyBosses = checklist.weeklyBosses.filter((boss) => boss.selected).length > 0;
+
+          return hasSelectedDailyBosses || hasSelectedWeeklyBosses;
+        });
       }
     });
 


### PR DESCRIPTION
This minor PR updates the initial app load redirect from the dailies page to the new dashboard page. It also includes an update to only show populated boss checklists (at least one selected boss from either list) on the dashboard.