### PR TITLE
Feature/guild points cap guide

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maple-dailies",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/framework/table/table.component.html
+++ b/src/app/framework/table/table.component.html
@@ -4,7 +4,7 @@
     <ng-container *ngIf="rows.length > 0; else noDataAvailable">
       <ng-content select="[table-body]"></ng-content>
     </ng-container>
-    <tfoot>
+    <tfoot *ngIf="pagination || showFooter">
       <tr>
         <td class="p-4 border-t-2 border-opacity-20 border-base-300" [attr.colspan]="columns.length">
           <div class="flex" [ngClass]="setFlexJustifyClass()">

--- a/src/app/framework/table/table.component.ts
+++ b/src/app/framework/table/table.component.ts
@@ -11,6 +11,7 @@ export class TableComponent implements OnInit, OnChanges {
   @Input() columns: TableColumn[] = [];
   @Input() compact = false;
   @Input() pagination = false;
+  @Input() showFooter = false;
   @Input() pageSize: PageSize = 10;
 
   rows: TableData[] = [];

--- a/src/app/pages/guides/components/guild-point-cap/guild-point-cap.component.html
+++ b/src/app/pages/guides/components/guild-point-cap/guild-point-cap.component.html
@@ -1,0 +1,73 @@
+<app-container>
+  <div class="mb-2">
+    Full credit goes to
+    <a
+      class="link link-primary"
+      href="https://www.reddit.com/r/Maplestory/comments/hccui0/easyish_way_to_get_reach_daily_max_guild/"
+      target="_blank"
+      >u/RizenNZ</a
+    >
+    for providing the following data. Use this guide in case you can't find someone in your guild to GP cap with or if you want collect all
+    MCC/Meister cubes that drop!
+  </div>
+
+  <div class="mb-2">
+    Notes: Magnus is highly recommended over Julieta since the Julieta fight is terribly buggy. Going down the list should get you to at
+    least 4,000 GP.
+  </div>
+  <app-table [columns]="dailyColumns" [data]="dailyBosses" #dailyTable>
+    <thead table-header>
+      <tr>
+        <th *ngFor="let column of dailyColumns" ngClass="text-{{ column.textAlign }}">
+          {{ column.headerTitle }}
+        </th>
+      </tr>
+    </thead>
+    <tbody table-body>
+      <tr *ngFor="let row of dailyTable.rows; let i = index">
+        <td class="text-left">
+          <div class="flex space-x-2">
+            <img src="assets/images/bosses/{{ row.iconFileName }}" alt="Boss Image" class="h-7 w-7" />
+            <div>
+              {{ row.bossName }}
+            </div>
+          </div>
+        </td>
+        <td class="text-center">
+          {{ row.contributionPoints }}
+        </td>
+      </tr>
+    </tbody>
+  </app-table>
+
+  <div class="divider"></div>
+
+  <div class="mb-2">
+    Notes: Select one weekly boss to reach 5,000 GP. Until the Marble of Chaos change gets reverted, remember that you can't defeat both
+    daily and weekly Pink Bean on the same day.
+  </div>
+  <app-table [columns]="weeklyColumns" [data]="weeklyBosses" #weeklyTable>
+    <thead table-header>
+      <tr>
+        <th *ngFor="let column of weeklyColumns" ngClass="text-{{ column.textAlign }}">
+          {{ column.headerTitle }}
+        </th>
+      </tr>
+    </thead>
+    <tbody table-body>
+      <tr *ngFor="let row of weeklyTable.rows; let i = index">
+        <td class="text-left">
+          <div class="flex space-x-2">
+            <img src="assets/images/bosses/{{ row.iconFileName }}" alt="Boss Image" class="h-7 w-7" />
+            <div>
+              {{ row.bossName }}
+            </div>
+          </div>
+        </td>
+        <td class="text-center">
+          {{ row.contributionPoints }}
+        </td>
+      </tr>
+    </tbody>
+  </app-table>
+</app-container>

--- a/src/app/pages/guides/components/guild-point-cap/guild-point-cap.component.ts
+++ b/src/app/pages/guides/components/guild-point-cap/guild-point-cap.component.ts
@@ -1,0 +1,166 @@
+import { Component, OnInit } from '@angular/core';
+import { TableColumn } from 'src/app/framework/table/table.types';
+import { GuildPointCapInfo } from '../../guides.types';
+
+@Component({
+  selector: 'app-guild-point-cap',
+  templateUrl: './guild-point-cap.component.html',
+})
+export class GuildPointCapComponent implements OnInit {
+  dailyColumns: TableColumn[] = [
+    {
+      headerTitle: 'Daily Boss',
+      textAlign: 'left',
+      width: '120',
+    },
+    {
+      headerTitle: 'Contribution Points (Solo)',
+      textAlign: 'center',
+      width: '80',
+    },
+  ];
+
+  weeklyColumns: TableColumn[] = [
+    {
+      headerTitle: 'Weekly Boss',
+      textAlign: 'left',
+      width: '120',
+    },
+    {
+      headerTitle: 'Contribution Points (Solo)',
+      textAlign: 'center',
+      width: '80',
+    },
+  ];
+
+  dailyBosses: GuildPointCapInfo[] = [
+    {
+      bossName: 'Normal Zakum',
+      contributionPoints: 100,
+      iconFileName: 'zakum.png',
+    },
+    {
+      bossName: 'Normal Magnus',
+      contributionPoints: 500,
+      iconFileName: 'magnus.png',
+    },
+    {
+      bossName: 'Normal Hilla',
+      contributionPoints: 100,
+      iconFileName: 'hilla.png',
+    },
+    {
+      bossName: 'OMNI-CLN',
+      contributionPoints: 250,
+      iconFileName: 'omni-cln.png',
+    },
+    {
+      bossName: 'Normal Papulatus',
+      contributionPoints: 500,
+      iconFileName: 'papulatus.png',
+    },
+    {
+      bossName: 'Normal Crimson Queen',
+      contributionPoints: 150,
+      iconFileName: 'crimson-queen.png',
+    },
+    {
+      bossName: 'Normal Pierre',
+      contributionPoints: 150,
+      iconFileName: 'pierre.png',
+    },
+    {
+      bossName: 'Normal Von Bon',
+      contributionPoints: 150,
+      iconFileName: 'von-bon.png',
+    },
+    {
+      bossName: 'Normal Vellum',
+      contributionPoints: 150,
+      iconFileName: 'vellum.png',
+    },
+    {
+      bossName: 'Hard Von Leon',
+      contributionPoints: 500,
+      iconFileName: 'von-leon.png',
+    },
+    {
+      bossName: 'Chaos Horntail',
+      contributionPoints: 250,
+      iconFileName: 'horntail.png',
+    },
+    {
+      bossName: 'Normal Arkarium',
+      contributionPoints: 500,
+      iconFileName: 'arkarium.png',
+    },
+    {
+      bossName: 'Normal Pink Bean',
+      contributionPoints: 250,
+      iconFileName: 'pink-bean.png',
+    },
+    {
+      bossName: 'Hard Mori Ranmaru',
+      contributionPoints: 500,
+      iconFileName: 'mori-ranmaru.png',
+    },
+
+    {
+      bossName: 'Julieta (x4)',
+      contributionPoints: 600,
+      iconFileName: 'julieta.png',
+    },
+  ];
+
+  weeklyBosses: GuildPointCapInfo[] = [
+    {
+      bossName: 'Chaos Zakum',
+      contributionPoints: 1000,
+      iconFileName: 'zakum.png',
+    },
+    {
+      bossName: 'Hard Magnus',
+      contributionPoints: 1250,
+      iconFileName: 'magnus.png',
+    },
+    {
+      bossName: 'Hard Hilla',
+      contributionPoints: 1000,
+      iconFileName: 'hilla.png',
+    },
+    {
+      bossName: 'Chaos Crimson Queen',
+      contributionPoints: 1000,
+      iconFileName: 'crimson-queen.png',
+    },
+    {
+      bossName: 'Chaos Pierre',
+      contributionPoints: 1000,
+      iconFileName: 'pierre.png',
+    },
+    {
+      bossName: 'Chaos Von Bon',
+      contributionPoints: 1000,
+      iconFileName: 'von-bon.png',
+    },
+    {
+      bossName: 'Chaos Vellum',
+      contributionPoints: 1250,
+      iconFileName: 'vellum.png',
+    },
+    {
+      bossName: 'Chaos Pink Bean',
+      contributionPoints: 1000,
+      iconFileName: 'pink-bean.png',
+    },
+    {
+      bossName: 'Easy/Normal Cygnus',
+      contributionPoints: 1000,
+      iconFileName: 'cygnus.png',
+    },
+  ];
+
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/pages/guides/guides.component.ts
+++ b/src/app/pages/guides/guides.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { faGlobe, faInfo, faMap, faUtensils } from '@fortawesome/free-solid-svg-icons';
+import { faGlobe, faInfo, faMap, faScroll, faUtensils } from '@fortawesome/free-solid-svg-icons';
 import { NavLink } from 'src/app/layout/header/header.types';
 
 @Component({
@@ -27,10 +27,10 @@ export class GuidesComponent implements OnInit {
       icon: faUtensils,
     },
     {
-      name: 'Maple Info Corner',
-      route: 'maple-info-corner',
+      name: 'Guild Point Cap',
+      route: 'guild-point-cap',
       matchExactRouteUrl: false,
-      icon: faInfo,
+      icon: faScroll,
     },
     // Commented out due to maple info corner only being http and being unable to load when app is built
     // {

--- a/src/app/pages/guides/guides.component.ts
+++ b/src/app/pages/guides/guides.component.ts
@@ -32,6 +32,13 @@ export class GuidesComponent implements OnInit {
       matchExactRouteUrl: false,
       icon: faInfo,
     },
+    // Commented out due to maple info corner only being http and being unable to load when app is built
+    // {
+    //   name: 'Maple Info Corner',
+    //   route: 'maple-info-corner',
+    //   matchExactRouteUrl: false,
+    //   icon: faInfo,
+    // },
   ];
 
   constructor() {}

--- a/src/app/pages/guides/guides.module.ts
+++ b/src/app/pages/guides/guides.module.ts
@@ -16,6 +16,7 @@ import { TrainingMapsComponent } from './components/training-maps/training-maps.
 import { TrainingMapsFiltersComponent } from './components/training-maps/components/training-maps-filters/training-maps-filters.component';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MapleInfoCornerComponent } from './components/maple-info-corner/maple-info-corner.component';
+import { GuildPointCapComponent } from './components/guild-point-cap/guild-point-cap.component';
 
 @NgModule({
   declarations: [
@@ -27,6 +28,7 @@ import { MapleInfoCornerComponent } from './components/maple-info-corner/maple-i
     TrainingMapsComponent,
     TrainingMapsFiltersComponent,
     MapleInfoCornerComponent,
+    GuildPointCapComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/pages/guides/guides.routes.ts
+++ b/src/app/pages/guides/guides.routes.ts
@@ -31,6 +31,11 @@ export const routes: Routes = [
         path: 'maple-info-corner',
         component: MapleInfoCornerComponent,
       },
+      // Commented out due to maple info corner only being http and being unable to load when app is built
+      // {
+      //   path: 'maple-info-corner',
+      //   component: MapleInfoCornerComponent,
+      // },
     ],
   },
 ];

--- a/src/app/pages/guides/guides.routes.ts
+++ b/src/app/pages/guides/guides.routes.ts
@@ -1,5 +1,6 @@
 import { Routes } from '@angular/router';
 import { ArcaneRiverDailiesInfoComponent } from './components/arcane-river-dailies-info/arcane-river-dailies-info.component';
+import { GuildPointCapComponent } from './components/guild-point-cap/guild-point-cap.component';
 import { HardMutoRecipesComponent } from './components/hard-muto-recipes/hard-muto-recipes.component';
 import { MapleInfoCornerComponent } from './components/maple-info-corner/maple-info-corner.component';
 import { TrainingMapsComponent } from './components/training-maps/training-maps.component';
@@ -28,8 +29,8 @@ export const routes: Routes = [
         component: HardMutoRecipesComponent,
       },
       {
-        path: 'maple-info-corner',
-        component: MapleInfoCornerComponent,
+        path: 'guild-point-cap',
+        component: GuildPointCapComponent,
       },
       // Commented out due to maple info corner only being http and being unable to load when app is built
       // {

--- a/src/app/pages/guides/guides.types.ts
+++ b/src/app/pages/guides/guides.types.ts
@@ -42,4 +42,10 @@ interface TrainingMap {
   popularity: string | null;
 }
 
-export { DailyInfo, DailyInfoList, MutoRecipeIngredient, MutoRecipe, TrainingMapsFiltersEvent, TrainingMap };
+interface GuildPointCapInfo {
+  bossName: string;
+  contributionPoints: number;
+  iconFileName: string;
+}
+
+export { DailyInfo, DailyInfoList, MutoRecipeIngredient, MutoRecipe, TrainingMapsFiltersEvent, TrainingMap, GuildPointCapInfo };

--- a/src/app/pages/settings/components/manage-characters/manage-characters.component.html
+++ b/src/app/pages/settings/components/manage-characters/manage-characters.component.html
@@ -1,5 +1,5 @@
 <app-container>
-  <app-table [columns]="columns" [data]="data" #table>
+  <app-table [columns]="columns" [data]="data" [showFooter]="true" #table>
     <thead table-header>
       <tr>
         <th


### PR DESCRIPTION
This PR temporarily removed the the maple info corner guide due to it only using http; it also adds a new guild point cap guide.