### PR TITLE
Bugfix/reintroduce maple info corner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maple-dailies",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/pages/guides/components/maple-info-corner/maple-info-corner.component.html
+++ b/src/app/pages/guides/components/maple-info-corner/maple-info-corner.component.html
@@ -1,7 +1,12 @@
 <app-container>
   <div class="mockup-window bg-base-200">
     <div class="bg-base-100 h-screen/70">
-      <iframe title="Maple Info Corner website" class="w-full h-full" src="http://whackybeanz.com/maple" frameborder="0"></iframe>
+      <iframe
+        title="Maple Info Corner website"
+        class="w-full h-full"
+        src="https://whacky-test.herokuapp.com/maple"
+        frameborder="0"
+      ></iframe>
     </div>
   </div>
 </app-container>

--- a/src/app/pages/guides/guides.component.ts
+++ b/src/app/pages/guides/guides.component.ts
@@ -33,18 +33,17 @@ export class GuidesComponent implements OnInit {
       icon: faScroll,
     },
     {
+      name: 'Maple Info Corner',
+      route: 'maple-info-corner',
+      matchExactRouteUrl: false,
+      icon: faInfo,
+    },
+    {
       name: `SuckHard's Calculators`,
       route: 'suckhard-calculators',
       matchExactRouteUrl: false,
       icon: faCalculator,
     },
-    // Commented out due to maple info corner only being http and being unable to load when app is built
-    // {
-    //   name: 'Maple Info Corner',
-    //   route: 'maple-info-corner',
-    //   matchExactRouteUrl: false,
-    //   icon: faInfo,
-    // },
   ];
 
   constructor() {}

--- a/src/app/pages/guides/guides.routes.ts
+++ b/src/app/pages/guides/guides.routes.ts
@@ -34,14 +34,13 @@ export const routes: Routes = [
         component: GuildPointCapComponent,
       },
       {
+        path: 'maple-info-corner',
+        component: MapleInfoCornerComponent,
+      },
+      {
         path: 'suckhard-calculators',
         component: SuckHardCalculatorsComponent,
       },
-      // Commented out due to maple info corner only being http and being unable to load when app is built
-      // {
-      //   path: 'maple-info-corner',
-      //   component: MapleInfoCornerComponent,
-      // },
     ],
   },
 ];


### PR DESCRIPTION
This minor PR readds the maple info corner iframe component with an https url.